### PR TITLE
Recruitment card

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -39,7 +39,7 @@ function Footer() {
   ];
 
   return (
-    <div className="flex w-full flex-col bg-footer-shadow pb-6 pt-6">
+    <div className="mt-80 flex w-full flex-col bg-footer-shadow pb-6 pt-6">
       <div className="mb-4 flex w-full flex-row items-center justify-between">
         {/* gatech logo */}
         <div className="ml-10 py-4 font-bayon text-3xl tracking-wide">

--- a/src/components/GameGrid.tsx
+++ b/src/components/GameGrid.tsx
@@ -7,7 +7,7 @@ function GameGrid() {
 
   return (
     <div className="flex flex-wrap justify-center px-[100px]">
-      <div className="w-full px-4 pb-8 font-barlow text-xl">
+      <div className="w-full px-4 pb-4 font-barlow text-xl">
         <button
           className={
             comp

--- a/src/components/RecruitmentCard.tsx
+++ b/src/components/RecruitmentCard.tsx
@@ -2,7 +2,7 @@ import { RecruitmentCardProps } from "../types";
 
 export default function RecruitmentCard(props: RecruitmentCardProps) {
   return (
-    <div className=" items box-content flex w-9/12 flex-row rounded-xl bg-gradient-to-br from-[#3d3d3d]/95 to-[#a7a7a7]/95">
+    <div className=" flex w-9/12 flex-row rounded-xl bg-gradient-to-br from-[#3d3d3d]/95 to-[#a7a7a7]/95">
       {/* game image + discord icon */}
       <div className="relative box-content h-[280px] w-[225px] border-0 p-4">
         <img
@@ -40,14 +40,11 @@ export default function RecruitmentCard(props: RecruitmentCardProps) {
           • discord: {props.contactDiscord}
         </p>
         {/* button here */}
-        <div className="mb-3 flex flex-row-reverse pr-4 pt-8">
-          <button className="learn-more-btn text-barlow ml-3 flex items-center justify-center tracking-wide">
+        <div className="mb-3 flex flex-row-reverse pr-6 pt-8">
+          <button className="learn-more-btn ml-3 mr-4 mt-6 flex scale-90 scale-x-[1.2] items-center justify-center tracking-tighter">
             Learn More
           </button>
         </div>
-        {/* <a href={props.discordLink} target="_blank">
-            <button className="discord-btn mr-3"></button>
-          </a> */}
       </div>
     </div>
   );

--- a/src/components/RecruitmentCard.tsx
+++ b/src/components/RecruitmentCard.tsx
@@ -2,7 +2,7 @@ import { RecruitmentCardProps } from "../types";
 
 export default function RecruitmentCard(props: RecruitmentCardProps) {
   return (
-    <div className=" flex w-9/12 flex-row rounded-xl bg-gradient-to-br from-[#3d3d3d]/95 to-[#a7a7a7]/95">
+    <div className=" items box-content flex w-9/12 flex-row rounded-xl bg-gradient-to-br from-[#3d3d3d]/95 to-[#a7a7a7]/95">
       {/* game image + discord icon */}
       <div className="relative box-content h-[280px] w-[225px] border-0 p-4">
         <img
@@ -17,20 +17,20 @@ export default function RecruitmentCard(props: RecruitmentCardProps) {
         </div>
       </div>
       {/* text info */}
-      <div className="tracking-wid flex w-full flex-col pl-1 pt-4">
-        <h1 className=" flex flex-row-reverse pr-8 font-barlow text-[0.95rem] font-semibold tracking-wide text-white">
-          Tryout date: 8/27/2023
+      <div className="box-content flex h-full w-full flex-col pl-1 pt-4 tracking-wider">
+        <h1 className=" flex flex-row-reverse pr-8 font-sans text-[0.97rem] font-semibold tracking-wide text-white">
+          Tryout date: {props.tryoutDate}
         </h1>
-        <h1 className="pb-2 font-bayon text-[1.4rem] tracking-wider text-bright-buzz">
+        <h1 className="pb-2 font-bayon text-[1.4rem] text-bright-buzz">
           {props.name}
         </h1>
-        <p className=" font-barlow text-[0.95rem] tracking-wider text-bright-buzz">
+        <p className=" font-barlow text-[0.95rem] text-bright-buzz">
           Recruitment Info:
         </p>
         <p className="tracking pl-3 font-barlow text-[0.9rem] font-light text-white">
           {props.recruitmentInfo}
         </p>
-        <p className="pt-2 font-barlow text-[.95rem] tracking-wider text-bright-buzz">
+        <p className="pt-2 font-barlow text-[.95rem] text-bright-buzz">
           Contact:
         </p>
         <p className="tracking pl-3 font-barlow text-[0.9rem] font-light text-white">
@@ -40,11 +40,14 @@ export default function RecruitmentCard(props: RecruitmentCardProps) {
           • discord: {props.contactDiscord}
         </p>
         {/* button here */}
-        <div className="mb-3 flex flex-row-reverse pr-6 pt-8">
-          <button className="learn-more-btn ml-3 mr-4 mt-6 flex scale-90 scale-x-[1.2] items-center justify-center tracking-tighter">
-            Learn More
-          </button>
-        </div>
+        {/* <a href={props.discordLink} target="_blank">
+            <button className="discord-btn mr-3"></button>
+          </a> */}
+      </div>
+      <div className="relative mb-3 pr-6 pt-8">
+        <button className="learn-more-btn absolute bottom-0 right-6 ml-3 mr-4 mt-6 flex scale-90 scale-x-[1.2] items-center justify-center tracking-tighter">
+          Learn More
+        </button>
       </div>
     </div>
   );

--- a/src/data/recruitmentData.ts
+++ b/src/data/recruitmentData.ts
@@ -31,6 +31,7 @@ export const recruitmentData = {
       "• Process: Play a couple games with the team and see how you do.",
     contactEmail: "leagueoflegends@gtesports.org",
     contactDiscord: "name#0000",
+    tryoutDate: "09/02/2024",
   },
   "Overwatch Tryout": {
     image: overwatch2,
@@ -39,6 +40,7 @@ export const recruitmentData = {
       "• Process: Play a couple games with the team and see how you do.",
     contactEmail: "ow2@gtesports.org",
     contactDiscord: "name#0000",
+    tryoutDate: "08/29/2024",
   },
   "Valorant Gold Team Tryout": {
     image: valorant,
@@ -47,5 +49,6 @@ export const recruitmentData = {
       "• Process: Play few rounds of scrimmage against other tryout attendees and top scorers will be invited to a final trial scrimmage against current team.",
     contactEmail: "valorant@gtesports.org",
     contactDiscord: "name#0000",
+    tryoutDate: "09/10/2024",
   },
 };

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -105,7 +105,7 @@ function Home() {
             ))}
           </div>
         </div>
-        <div className="mb-64 mt-32 flex flex-col items-center">
+        <div className="mt-32 flex flex-col items-center pb-40">
           <div className="mb-8 flex w-full flex-row items-center justify-between">
             <h2 className="font-bayon text-5xl font-normal text-white">
               EVENTS

--- a/src/pages/Recruitment.tsx
+++ b/src/pages/Recruitment.tsx
@@ -23,6 +23,7 @@ function Recruitment() {
                 discordLink={game.discordLink}
                 contactEmail={game.contactEmail}
                 contactDiscord={game.contactDiscord}
+                tryoutDate={game.tryoutDate}
               />
             </div>
           ))}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -12,4 +12,5 @@ export interface RecruitmentCardProps {
   recruitmentInfo: string;
   contactEmail: string;
   contactDiscord: string;
+  tryoutDate: string;
 }


### PR DESCRIPTION
Users can see recruitment cards on page.

Image updated to be put within a div with another span for the Discord-btn overlay. 

<img width="1430" alt="Screenshot 2024-05-18 at 7 06 14 PM" src="https://github.com/gt-esports/gtesports-website/assets/71297198/ee71a6f5-2b55-479d-8682-4c35593d8ed5">

to be done:
- complete header as seen in the figma document
- complete functionality for the "Learn more" button
